### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
 
   flask:


### PR DESCRIPTION
removing first line:  
`version: '3.7'  `

removing it after seeing this under compose pull:
```
❯ docker-compose pull                                                                                              
WARN[0000]  /docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```