### PR TITLE
Add version parameter to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.7'
 services:
 
   flask:


### PR DESCRIPTION
docker-compose version: 1.25

Without adding `version`, it is impossible to run on systems with docker-compose v1, like on debian 11:
![изображение](https://github.com/user-attachments/assets/648230fd-4b2a-45c4-97fd-3f6e2cdc4279)

To keep compatibility, it is better to add the `version` parameter to docker-compose.yml