### PR TITLE
README: add cp env.example .env to Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ To get Topolograph Docker up and running run the following commands.
 ```bash
 git clone https://github.com/Vadims06/topolograph-docker.git
 cd topolograph-docker
+cp env.example .env
 docker-compose pull
 docker-compose up -d
 ```


### PR DESCRIPTION
## Summary
- Adds `cp env.example .env` to the Quickstart section
- Without this step, fresh clones fail to start because `$MONGODB_HOSTNAME` and other vars are empty, causing a pymongo `Empty host` error
## Test plan
- [ ] Clone repo, run `cp env.example .env && docker-compose up -d`, verify Topolograph starts at `http://localhost:8080/`

